### PR TITLE
fix: change the firebase private key format to JSON string

### DIFF
--- a/src/connections/firebase.ts
+++ b/src/connections/firebase.ts
@@ -17,11 +17,13 @@ type Config = {
 
 };
 
+const { privateKey } = JSON.parse(<string>process.env.FIREBASE_PRIVATE_KEY)
+
 const config: Config = {
   type: process.env.FIREBASE_TYPE || '',
   project_id: process.env.FIREBASE_PROJECT_ID || '',
   private_key_id: process.env.FIREBASE_PRIVATE_KEY_ID || '',
-  private_key: (process.env.FIREBASE_PRIVATE_KEY || '').replace(/\\n/g, '\n'),
+  private_key: privateKey || '',
   client_email: process.env.FIREBASE_CLIENT_EMAIL || '',
   client_id: process.env.FIREBASE_CLIENT_ID || '',
   auth_uri: process.env.FIREBASE_AUTH_URI || '',


### PR DESCRIPTION
[Description]
1. The Render service cannot parse the string configuration of the FIREBASE_PRIVATE_KEY environment variable in Firebase, so it uses a JSON string instead.